### PR TITLE
Option in time selection for current time

### DIFF
--- a/location.go
+++ b/location.go
@@ -49,7 +49,6 @@ func newLocation(loc *city, n *nomad, homeC *fyne.Container) *location {
 			hour = time.Now().Hour()
 			minute = time.Now().Minute()
 			l.time.SetText(fmt.Sprintf("%02d:%02d", hour, minute))
-
 		} else {
 			fmt.Sscanf(s, "%d:%d", &hour, &minute)
 		}


### PR DESCRIPTION
Fixes #34 

Added "Now" as an option in the time picker which sets the hour and minute to time.Now()