### PR TITLE
Fix ipad clipping on the right

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -22,7 +22,7 @@ func (l *nomadLayout) Layout(objs []fyne.CanvasObject, s fyne.Size) {
 		outer = 0
 	}
 	l.cols = int((s.Width - outer*2 + cellSpace) / (minWidth + cellSpace))
-	colWidth := (s.Width-outer)/float32(l.cols) - outer
+	colWidth := (s.Width-outer*2+cellSpace)/float32(l.cols) - cellSpace
 	cellSize := fyne.NewSize(colWidth, minHeight)
 
 	offset := 0


### PR DESCRIPTION
A little bad maths in "mobile" mode. It worked on desktop because `outer == cellSpace`.

Before:
![IMG_0020](https://user-images.githubusercontent.com/294436/176913255-e24841f2-4212-42f4-bcaf-312ee80006fc.PNG)

After:
![IMG_0023](https://user-images.githubusercontent.com/294436/176913603-494623f4-97a7-41c9-b239-a4755c88c32f.PNG)
