### PR TITLE
Allow 'Add A Place' entry field to be visible

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -48,7 +48,7 @@ func (l *nomadLayout) MinSize(cells []fyne.CanvasObject) fyne.Size {
 		cols = 1
 	}
 	rows := int(math.Ceil(float64(len(cells)) / float64(l.cols)))
-	height := float32((minHeight+cellSpace)*float32(rows) - cellSpace)
+	height := float32((minHeight+cellSpace*4)*float32(rows) - cellSpace)
 	if fyne.CurrentDevice().IsMobile() {
 		return fyne.NewSize(minWidth, height)
 	}

--- a/layout.go
+++ b/layout.go
@@ -48,12 +48,12 @@ func (l *nomadLayout) MinSize(cells []fyne.CanvasObject) fyne.Size {
 		cols = 1
 	}
 	rows := int(math.Ceil(float64(len(cells)) / float64(l.cols)))
-	height := float32((minHeight+cellSpace)*float32(rows) - cellSpace)
+	height := float32((minHeight+cellSpace*4)*float32(rows) - cellSpace)
 	if fyne.CurrentDevice().IsMobile() {
 		return fyne.NewSize(minWidth, height)
 	}
 
-	return fyne.NewSize(minWidth, height+cellSpace*16)
+	return fyne.NewSize(minWidth, height+cellSpace*2)
 }
 
 func (l *nomadLayout) minOuterSize() fyne.Size {

--- a/layout.go
+++ b/layout.go
@@ -48,12 +48,12 @@ func (l *nomadLayout) MinSize(cells []fyne.CanvasObject) fyne.Size {
 		cols = 1
 	}
 	rows := int(math.Ceil(float64(len(cells)) / float64(l.cols)))
-	height := float32((minHeight+cellSpace*4)*float32(rows) - cellSpace)
+	height := float32((minHeight+cellSpace)*float32(rows) - cellSpace)
 	if fyne.CurrentDevice().IsMobile() {
 		return fyne.NewSize(minWidth, height)
 	}
 
-	return fyne.NewSize(minWidth, height+cellSpace*2)
+	return fyne.NewSize(minWidth, height+cellSpace*16)
 }
 
 func (l *nomadLayout) minOuterSize() fyne.Size {


### PR DESCRIPTION
Perhaps not the most elegant solution but a solution that doesn't require 'Entry' to be extended/modified. 
I was unable to find a way to determine if the entry field was clicked/focused, any listeners for this action are not exported I believe(?). 
This solution allows users to scroll down and see the entry field by creating more space at the bottom of the layout. Dirty, I know, but I've made little progress on this task to date and wanted to get the ball rolling. 

Fixes #71 

<img src="https://user-images.githubusercontent.com/45520351/179774506-edf4190f-a1d2-4603-9ccf-815ccfb1d554.jpg" width="400" />
<img src="https://user-images.githubusercontent.com/45520351/179774917-336d090b-eb8f-4078-a3d3-008f1043522f.jpg" width="400" />